### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,20 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: plateau-webar
+  namespace: eukarya-inc
+  annotations:
+    github.com/project-slug: eukarya-inc/plateau-webar
+  links:
+  - url: https://github.com/eukarya-inc/plateau-webar
+    title: GitHub
+    icon: github
+  - url: https://reearth-webar.vercel.app
+    title: Website
+    icon: web
+  tags:
+  - typescript
+spec:
+  type: service
+  lifecycle: production
+  owner: eukarya-inc/plateau


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `plateau-webar` (namespace `eukarya-inc`)
- **Owner:** `eukarya-inc/plateau`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.